### PR TITLE
Added custom yOrderComparator function for vertical ordering of nodes

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -145,7 +145,8 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     height = NULL, width = NULL, iterations = 32, zoom = FALSE, align = "justify",
     showNodeValues = TRUE, linkType = "bezier", curvature = .5,  linkColor = "#A0A0A0",
     nodeLabelMargin = 2, linkOpacity = .5, linkGradient = FALSE, nodeShadow = FALSE, 
-    scaleNodeBreadthsByString = FALSE, xScalingFactor = 1) 
+    scaleNodeBreadthsByString = FALSE, xScalingFactor = 1,
+    yOrderComparator = NULL) 
 {
     # Check if data is zero indexed
     check_zero(Links[, Source], Links[, Target])
@@ -215,7 +216,8 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
         showNodeValues = showNodeValues, align = align, xAxisDomain = xAxisDomain,
         title = title, nodeLabelMargin = nodeLabelMargin, 
         linkColor = linkColor, linkOpacity = linkOpacity, linkGradient = linkGradient, nodeShadow = nodeShadow,
-        scaleNodeBreadthsByString = scaleNodeBreadthsByString, xScalingFactor = xScalingFactor)
+        scaleNodeBreadthsByString = scaleNodeBreadthsByString, xScalingFactor = xScalingFactor,
+        yOrderComparator = yOrderComparator)
     
     # create widget
     htmlwidgets::createWidget(name = "sankeyNetwork", x = list(links = LinksDF, 

--- a/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
+++ b/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
@@ -17,6 +17,13 @@ d3.sankey = function() {
       nodeCornerRadius = 0,
       nodes = [],
       links = [];
+      yOrderComparator = function ascendingDepth(a, b) {
+        if (orderByPath) {
+          return ( a.path < b.path ? -1 : (a.path > b.path ? 1 : 0 ));
+        } else {
+          return a.y - b.y;
+        }
+      }
 
   sankey.nodeWidth = function(_) {
     if (!arguments.length) return nodeWidth;
@@ -101,6 +108,12 @@ d3.sankey = function() {
 
   sankey.relayout = function() {
     computeLinkDepths();
+    return sankey;
+  };
+  
+   sankey.yOrderComparator = function(_) {
+    if (!arguments.length) return yOrderComparator;
+    yOrderComparator = _;
     return sankey;
   };
 
@@ -556,7 +569,7 @@ d3.sankey = function() {
             i;
 
         // Push any overlapping nodes down.
-        nodes.sort(ascendingDepth);
+        nodes.sort(yOrderComparator);
         for (i = 0; i < n; ++i) {
           node = nodes[i];
           dy = y0 - node.y;
@@ -578,14 +591,6 @@ d3.sankey = function() {
           }
         }
       });
-    }
-
-    function ascendingDepth(a, b) {
-      if (orderByPath) {
-        return ( a.path < b.path ? -1 : (a.path > b.path ? 1 : 0 ));
-      } else {
-        return a.y - b.y;
-      }
     }
   }
 

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -129,7 +129,7 @@ HTMLWidgets.widget({
           }
           return formated_num;
         }
-
+        
         // create d3 sankey layout
         sankey
             .nodes(d3.values(nodes))
@@ -143,9 +143,13 @@ HTMLWidgets.widget({
             .curvature(options.curvature)
             .orderByPath(options.orderByPath)
             .showNodeValues(options.showNodeValues)
-            .nodeCornerRadius(options.nodeCornerRadius)
-            .layout(options.iterations);
+            .nodeCornerRadius(options.nodeCornerRadius);
+            
+        if(options.yOrderComparator) {
+          sankey = sankey.yOrderComparator(eval(options.yOrderComparator));
+        }
 
+        sankey.layout(options.iterations);
 
         var max_posX = d3.max(sankey.nodes(), function(d) { return d.posX; });
         sankey.nodes().forEach(function(node) { node.x = node.x * options.xScalingFactor; });

--- a/man/sankeyNetwork.Rd
+++ b/man/sankeyNetwork.Rd
@@ -20,7 +20,8 @@ sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, NodeGroup = NodeID,
   showNodeValues = TRUE, linkType = "bezier", curvature = 0.5,
   linkColor = "#A0A0A0", nodeLabelMargin = 2, linkOpacity = 0.5,
   linkGradient = FALSE, nodeShadow = FALSE,
-  scaleNodeBreadthsByString = FALSE, xScalingFactor = 1)
+  scaleNodeBreadthsByString = FALSE, xScalingFactor = 1,
+  yOrderComparator = NULL)
 }
 \arguments{
 \item{Links}{a data frame object with the links between the nodes. It should
@@ -138,6 +139,8 @@ If 'none', then the labels of the nodes are always to the right of the node.}
 only work well currently with align='none'}
 
 \item{xScalingFactor}{numeric Scale the computed x position of the nodes by this value.}
+
+\item{yOrderComparator}{Javascript comparison function for custom vertical sort of nodes. Default is sort by ascending breadth. Use e.g. yOrderComparator = JS("function(a, b){return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;}") to sort by name.}
 }
 \description{
 Create a D3 JavaScript Sankey diagram


### PR DESCRIPTION
Added a parameter to pass a custom node comparator function down to sankey-d3. Also had to change the included sankey-d3 code to actually use the comparator function.

Could help https://github.com/fbreitwieser/sankeyD3/issues/2 and https://github.com/fbreitwieser/sankeyD3/issues/6 if I understand them correctly.