### PR TITLE
Added `NodePosY` argument to sankeyNetwork.R to control y position of nodes

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -52,6 +52,8 @@ NULL
 #' \code{Links}. Used to color the links in the network.
 #' @param NodePosX character specifying a column in the \code{Nodes} data
 #' frame that specifies the 0-based ordering of the nodes along the x-axis.
+#' @param NodePosY character specifying a column in the \code{Nodes} data
+#' frame that specifies the 0-based ordering of the nodes along the y-axis.
 #' @param NodeValue character specifying a column in the \code{Nodes} data
 #' frame with the value/size of each node. If \code{NULL}, the value is 
 #' calculated based on the maximum of the sum of incoming and outoging 

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -203,6 +203,9 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
 
     if (is.character(NodePosY)) {
         NodesDF$posY <- Nodes[, NodePosY]
+        orderByPosY <- TRUE
+    }else{
+        orderByPosY <- FALSE
     }
     
     if (is.character(NodePosX)) {
@@ -232,7 +235,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     margin <- margin_handler(margin)
     
     # create options
-    options = list(NodeID = NodeID, NodeGroup = NodeGroup, LinkGroup = LinkGroup, 
+    options = list(NodeID = NodeID, NodeGroup = NodeGroup, LinkGroup = LinkGroup, orderByPosY = orderByPosY,
         colourScale = colourScale, fontSize = fontSize, fontFamily = fontFamily, fontColor = fontColor,
         nodeWidth = nodeWidth, nodePadding = nodePadding, nodeStrokeWidth = nodeStrokeWidth,
         nodeCornerRadius = nodeCornerRadius, dragX = dragX, dragY = dragY,

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -156,7 +156,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     height = NULL, width = NULL, iterations = 32, zoom = FALSE, align = "justify",
     showNodeValues = TRUE, linkType = "bezier", curvature = .5,  linkColor = "#A0A0A0",
     nodeLabelMargin = 2, linkOpacity = .5, linkGradient = FALSE, nodeShadow = FALSE, 
-    scaleNodeBreadthsByString = FALSE, xScalingFactor = 1,
+    scaleNodeBreadthsByString = FALSE, xScalingFactor = 1, NodePosY = NULL,
     yOrderComparator = NULL) 
 {
     # Check if data is zero indexed
@@ -201,6 +201,10 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
         NodesDF$group <- Nodes[, NodeGroup]
     }
 
+    if (is.character(NodePosY)) {
+        NodesDF$posY <- Nodes[, NodePosY]
+    }
+    
     if (is.character(NodePosX)) {
         NodesDF$posX <- Nodes[, NodePosX]
     }

--- a/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
+++ b/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
@@ -57,7 +57,11 @@ d3.sankey = function() {
     orderByPath = _;
     return sankey;
   };
-
+  sankey.orderByPosY = function(_) {
+    if (!arguments.length) return orderByPosY;
+    orderByPosY = _;
+    return sankey;
+  };
   sankey.curvature = function(_) {
     if (!arguments.length) return curvature;
     curvature = _;

--- a/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
+++ b/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
@@ -21,7 +21,7 @@ d3.sankey = function() {
       yOrderComparator = function ascendingDepth(a, b) {
         if (orderByPath) {
           return ( a.path < b.path ? -1 : (a.path > b.path ? 1 : 0 ));
-        } else if(orderByPosY) {
+        } else if(false) {
           return a.posY - b.posY;
         }else {
           return a.y - b.y;

--- a/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
+++ b/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
@@ -22,7 +22,11 @@ d3.sankey = function() {
         if (orderByPath) {
           return ( a.path < b.path ? -1 : (a.path > b.path ? 1 : 0 ));
         } else if(orderByPosY) {
-          return a.posY - b.posY;
+          if(a.posY != b.posY){
+            return a.posY - b.posY;
+          }else{
+            return a.y - b.y
+          }
         }else {
           return a.y - b.y;
         }

--- a/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
+++ b/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
@@ -21,7 +21,7 @@ d3.sankey = function() {
       yOrderComparator = function ascendingDepth(a, b) {
         if (orderByPath) {
           return ( a.path < b.path ? -1 : (a.path > b.path ? 1 : 0 ));
-        } else if(false) {
+        } else if(orderByPosY) {
           return a.posY - b.posY;
         }else {
           return a.y - b.y;

--- a/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
+++ b/inst/htmlwidgets/lib/d3-sankey/src/sankey.js
@@ -11,6 +11,7 @@ d3.sankey = function() {
       linkType = 'bezier',
       reverse = false,
       orderByPath = false,
+      orderByPosY = false,
       scaleNodeBreadthsByString = false,
       curvature = .5,
       showNodeValues = false,
@@ -20,7 +21,9 @@ d3.sankey = function() {
       yOrderComparator = function ascendingDepth(a, b) {
         if (orderByPath) {
           return ( a.path < b.path ? -1 : (a.path > b.path ? 1 : 0 ));
-        } else {
+        } else if(orderByPosY) {
+          return a.posY - b.posY;
+        }else {
           return a.y - b.y;
         }
       }

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -144,6 +144,7 @@ HTMLWidgets.widget({
             .scaleNodeBreadthsByString(options.scaleNodeBreadthsByString)
             .curvature(options.curvature)
             .orderByPath(options.orderByPath)
+	    .orderByPosY(options.orderByPosY)
             .showNodeValues(options.showNodeValues)
             .nodeCornerRadius(options.nodeCornerRadius);
             

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -144,7 +144,7 @@ HTMLWidgets.widget({
             .scaleNodeBreadthsByString(options.scaleNodeBreadthsByString)
             .curvature(options.curvature)
             .orderByPath(options.orderByPath)
-	    .orderByPosY(options.orderByPosY)
+            .orderByPosY(options.orderByPosY)
             .showNodeValues(options.showNodeValues)
             .nodeCornerRadius(options.nodeCornerRadius);
             


### PR DESCRIPTION
It was not clear to me what form the `yOrderComparator` argument should take in pull request #16 so I added a `NodePosY` argument to `sankeyNetwork` to allow the user to directly specify the y position of nodes.